### PR TITLE
chore: make the version for the FROM image configurable.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM bucharestgold/centos7-s2i-nodejs:latest
+ARG BG_IMAGE_TAG
+FROM bucharestgold/centos7-s2i-nodejs:${BG_IMAGE_TAG}
 # This image provides a Node.JS environment you can use to build your Modern Web Applications
 
 EXPOSE 8080

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # other than the README.md file.
 include versions.mk
 
-FROM=bucharestgold/centos7-s2i-nodejs
+FROM=bucharestgold/centos7-s2i-nodejs:${BG_IMAGE_TAG}
 IMAGE_NAME=bucharestgold/centos7-s2i-web-app
 
 TARGET=$(IMAGE_NAME):$(IMAGE_TAG)
@@ -12,7 +12,7 @@ TARGET=$(IMAGE_NAME):$(IMAGE_TAG)
 all: build squash
 
 build: Dockerfile s2i
-	docker build -t $(TARGET) .
+	docker build --build-arg BG_IMAGE_TAG=$(BG_IMAGE_TAG) -t $(TARGET) .
 
 .PHONY: squash
 squash:
@@ -30,11 +30,10 @@ clean:
 .PHONY: tag
 tag:
 	if [ ! -z $(LTS_TAG) ]; then docker tag $(TARGET) $(IMAGE_NAME):$(LTS_TAG); fi
-	docker tag $(TARGET) $(IMAGE_NAME):$(NODE_VERSION)
+	docker tag $(TARGET) $(IMAGE_NAME):$(IMAGE_TAG)
 
 .PHONY: publish
 publish: all
 	echo $(DOCKER_PASS) | docker login -u $(DOCKER_USER) --password-stdin
 	docker push $(TARGET)
-	docker push $(IMAGE_NAME):$(NODE_VERSION)
 	if [ ! -z $(LTS_TAG) ]; then docker push $(IMAGE_NAME):$(LTS_TAG); fi

--- a/versions.mk
+++ b/versions.mk
@@ -1,1 +1,3 @@
-IMAGE_TAG=0.0.3
+IMAGE_TAG=latest
+BG_IMAGE_TAG=latest
+LTS_TAG=


### PR DESCRIPTION
start using the latest tag name

fixes #10 


There isn't really a difference between the BG_IMAGE_TAG and IMAGE_TAG since they will probably always be the same,  but i feel like we need both, but not sure why

Once this gets in, then we can make a 10.x and 8.x branch