### PR TITLE
feat: Optimizations for a better developer workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ EXPOSE 8080
 
 ENV OUTPUT_DIR=build \
     NPM_BUILD_COMMAND="npm run build" \
+    DEPLOY_DIR=/opt/app-root/output \
+    DEPLOY_PORT=8080 \
     DEBUG_PORT=5858 \
     NODE_VERSION=${NODE_VERSION} \
     NPM_VERSION=${NPM_VERSION} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ FROM bucharestgold/centos7-s2i-nodejs:${BG_IMAGE_TAG}
 EXPOSE 8080
 
 ENV OUTPUT_DIR=build \
-    NPM_BUILD_COMMAND="npm run build" \
-    DEPLOY_DIR=/opt/app-root/output \
+    NPM_BUILD="npm run build" \
     DEPLOY_PORT=8080 \
     DEBUG_PORT=5858 \
     NODE_VERSION=${NODE_VERSION} \

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ NAME        | Description
 ------------|-------------
 OUTPUT_DIR  | Sets the location of the output directory
 NPM_BUILD_COMMAND | Override the default "npm run build"
+NPM_RUN_COMMAND | Override the default "npx serve" command
+DEPLOY_PORT | Override the default(8080) port that the serve module uses
 NPM_MIRROR  | Sets the npm registry URL
 HTTP_PROXY  | use an npm proxy during assembly
 HTTPS_PROXY | use an npm proxy during assembly
@@ -54,3 +56,22 @@ in a `.s2i/environment` file in your source repository.
 
 Example: `DATABASE_USER=sampleUser`
 
+### Using for development
+
+While it is recommended to just use this image as a pure builder image, it can also be used for development.
+
+Taking React as an example, you can deploy your React Application to Openshift using something like this:
+
+`npx nodeshift --strictSSL=false --dockerImage=bucharestgold/centos7-s2i-web-app --build.env YARN_ENABLED=true --deploy.env NPM_RUN_COMMAND="yarn start" --deploy.port=3000 --expose`
+
+This will deploy the application and start the React Dev server(yarn start).
+
+Make sure to do this on your code directory, `chmod -R g+w .`, it is needed for the next step
+
+Then you can use the `oc sync` command to push changes from your local machine to your running deployment:
+
+oc rsync --progress --watch ./src POD_NAME:/opt/app-root/src
+
+_note: a quick way to get a pod name is `oc get pods | grep react-web-app | grep Running | awk '{print $1}'`_
+
+Make a change locally, and it will be pushed to your running deployment, where the react dev server will recompile your app and refresh your browser.

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ application image created from this builder image.
 NAME        | Description
 ------------|-------------
 OUTPUT_DIR  | Sets the location of the output directory
-NPM_BUILD_COMMAND | Override the default "npm run build"
-NPM_RUN_COMMAND | Override the default "npx serve" command
+NPM_BUILD | Override the default "npm run build"
+NPM_RUN | Override the default "npx serve" command
 DEPLOY_PORT | Override the default(8080) port that the serve module uses
 NPM_MIRROR  | Sets the npm registry URL
 HTTP_PROXY  | use an npm proxy during assembly
@@ -62,13 +62,13 @@ While it is recommended to just use this image as a pure builder image, it can a
 
 Taking React as an example, you can deploy your React Application to Openshift using something like this:
 
-`npx nodeshift --strictSSL=false --dockerImage=bucharestgold/centos7-s2i-web-app --build.env YARN_ENABLED=true --deploy.env NPM_RUN_COMMAND="yarn start" --deploy.port=3000 --expose`
+`npx nodeshift --strictSSL=false --dockerImage=bucharestgold/centos7-s2i-web-app --build.env YARN_ENABLED=true --deploy.env NPM_RUN="yarn start" --deploy.port=3000 --expose`
 
 This will deploy the application and start the React Dev server(yarn start).
 
 Make sure to do this on your code directory, `chmod -R g+w .`, it is needed for the next step
 
-Then you can use the `oc sync` command to push changes from your local machine to your running deployment:
+Then you can use the `oc rsync` command to push changes from your local machine to your running deployment:
 
 oc rsync --progress --watch ./src POD_NAME:/opt/app-root/src
 

--- a/s2i/assemble
+++ b/s2i/assemble
@@ -55,15 +55,15 @@ else
 	echo "---> Installing dependencies"
 	echo "---> Using 'npm install'"
 	npm install -s
-	$NPM_BUILD_COMMAND
+	$NPM_BUILD
 	# npm run build
 	echo "---> Cleaning up npm cache"
 	rm -rf .npm
 fi
 
-echo "----> moving built web application to $DEPLOY_DIR"
-mkdir -p $DEPLOY_DIR
-mv ./$OUTPUT_DIR/* $DEPLOY_DIR
+echo "----> moving built web application to /opt/app-root/output"
+mkdir -p /opt/app-root/output
+mv ./$OUTPUT_DIR/* /opt/app-root/output
 
 
 # echo "---> Building and Installing Web Application from source..."

--- a/s2i/assemble
+++ b/s2i/assemble
@@ -61,7 +61,6 @@ else
 	rm -rf .npm
 fi
 
-DEPLOY_DIR=/opt/app-root/output
 echo "----> moving built web application to $DEPLOY_DIR"
 mkdir -p $DEPLOY_DIR
 mv ./$OUTPUT_DIR/* $DEPLOY_DIR
@@ -74,3 +73,6 @@ mv ./$OUTPUT_DIR/* $DEPLOY_DIR
 # if [ -f /tmp/src/nginx.conf ]; then
 #   mv /tmp/src/nginx.conf /etc/nginx/nginx.conf
 # fi
+
+echo "---> Fix permissions on app-root"
+fix-permissions /opt/app-root

--- a/s2i/run
+++ b/s2i/run
@@ -7,10 +7,10 @@ echo -e "Running as user $(id)"
 echo "Running this container is only recommended when running in test or development."
 echo "It is recommended to use this s2i image as a pure builder image and use it with an openshift chain build https://docs.okd.io/latest/dev_guide/builds/advanced_build_operations.html#dev-guide-chaining-builds"
 
-if [ ! -z "$NPM_RUN_COMMAND" ]; then
-  $NPM_RUN_COMMAND
+if [ ! -z "$NPM_RUN" ]; then
+  $NPM_RUN
 else
-  npx serve -s $DEPLOY_DIR -l $DEPLOY_PORT
+  npx serve -s /opt/app-root/output -l $DEPLOY_PORT
 fi
 
 # # Allow debugging the builder image itself, by using:

--- a/s2i/run
+++ b/s2i/run
@@ -5,9 +5,13 @@ set -e
 echo -e "Running as user $(id)"
 
 echo "Running this container is only recommended when running in test or development."
-echo "It is recommended to use this s2i image as a pure builder image and use it with an openshift chain buildhttps://docs.okd.io/latest/dev_guide/builds/advanced_build_operations.html#dev-guide-chaining-builds"
+echo "It is recommended to use this s2i image as a pure builder image and use it with an openshift chain build https://docs.okd.io/latest/dev_guide/builds/advanced_build_operations.html#dev-guide-chaining-builds"
 
-npx serve -s $DEPLOY_DIR -l 8080
+if [ ! -z "$NPM_RUN_COMMAND" ]; then
+  $NPM_RUN_COMMAND
+else
+  npx serve -s $DEPLOY_DIR -l $DEPLOY_PORT
+fi
 
 # # Allow debugging the builder image itself, by using:
 # # $ docker run -it bucharestgold/centos-s2i-nodejs --debug


### PR DESCRIPTION
This includes adding a NPM_RUN_COMMAND variable that allows the user to specify what to run in the run phase(when not using a chain build).  For example, you could run a react dev server that could watch for changes in your code.

Also fixes an issue where the DEPLOY_DIR wasn't set correctly and the app would show a directory listing instead.

Adds a DEPLOY_PORT variable to override the port that the serve module uses.

fixes #8 

There is an issue when using an Ember app, a core dump happens, but it is related to this: https://gist.github.com/lholmquist/85aeabb95744034166b3914620df2407

