### PR TITLE
test: NPM_RUN workaround and enabling tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,9 @@ FROM bucharestgold/centos7-s2i-nodejs:${BG_IMAGE_TAG}
 EXPOSE 8080
 
 ENV OUTPUT_DIR=build \
+    NPM_RUN= \
     NPM_BUILD="npm run build" \
     DEPLOY_PORT=8080 \
-    DEBUG_PORT=5858 \
-    NODE_VERSION=${NODE_VERSION} \
-    NPM_VERSION=${NPM_VERSION} \
     SUMMARY="Platform for building Modern Web Applications that use Node.js" \
     DESCRIPTION="Web Application building with Node.js"
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ IMAGE_NAME=bucharestgold/centos7-s2i-web-app
 TARGET=$(IMAGE_NAME):$(IMAGE_TAG)
 
 .PHONY: all
-all: build squash
+all: build squash test
 
 build: Dockerfile s2i
 	docker build --build-arg BG_IMAGE_TAG=$(BG_IMAGE_TAG) -t $(TARGET) .


### PR DESCRIPTION
* The docker run for the example app is running in background , I can't find a way to run it without this workaround.

Connects to #18 and #15 

