### PR TITLE
chore: use npx for yarn installs and builds

### DIFF
--- a/s2i/assemble
+++ b/s2i/assemble
@@ -49,8 +49,8 @@ echo -e "Current git config"
 git config --list
 if [ ! -z "$YARN_ENABLED" ]; then
 	echo "---> Using 'yarn install' with YARN_ARGS"
-	yarn install $YARN_ARGS
-	yarn build
+	npx yarn install $YARN_ARGS
+	npx yarn build
 else
 	echo "---> Installing dependencies"
 	echo "---> Using 'npm install'"


### PR DESCRIPTION
* the most recent updated versions of the centos7-s2i-nodejs images, removed the yarn install, so we need to call yarn like this now, to make it work

should be cherry picked into 11.x and 10.x

fixes #40