### PR TITLE
Allow npm loglevel override

### DIFF
--- a/s2i/assemble
+++ b/s2i/assemble
@@ -2,6 +2,8 @@
 
 set -e
 
+export NPM_CONFIG_LOGLEVEL=${NPM_CONFIG_LOGLEVEL-silent}
+
 # Check to see if there is a node_modules folder
 if [ "$(ls -A /tmp/src/node_modules)" ]; then
 	echo "---> Removing the node_modules folder"
@@ -64,7 +66,7 @@ if [ ! -z "$YARN_ENABLED" ]; then
 else
 	echo "---> Installing dependencies"
 	echo "---> Using 'npm install'"
-	npm install -s
+	npm install
 	$NPM_BUILD
 	# npm run build
 	echo "---> Cleaning up npm cache"


### PR DESCRIPTION
The `-s` argument to `npm install` is equivalent to `--loglevel silent`.  If `npm install -s` fails it doesn't provide any helpful information.  This will preserve the existing behavior and allow for an override when needed.  To use this feature set an environment variable NPM_CONFIG_LOGLEVEL to one of "silent", "error", "warn", "notice", "http", "timing", "info", "verbose", or "silly". Documentation here: https://docs.npmjs.com/cli/v7/using-npm/config#loglevel

Example output with no NPM_CONFIG_LOGLEVEL set (this is the same behavior I currently see in the published image):
```
...
STEP 10: RUN /tmp/scripts/assemble
ls: cannot access '/tmp/src/node_modules': No such file or directory
---> Installing application source
---> Building your Web Application from source
---> Installing dependencies
---> Using 'npm install'
error: build error: error building at STEP "RUN /tmp/scripts/assemble": error while running runtime: exit status 254
```

And with NPM_CONFIG_LOGLEVEL=error:
```
...
STEP 10: RUN /tmp/scripts/assemble
ls: cannot access '/tmp/src/node_modules': No such file or directory
---> Installing application source
---> Building your Web Application from source
---> Installing dependencies
---> Using 'npm install'
npm ERR! code ENOENT
npm ERR! syscall spawn git
npm ERR! path git
npm ERR! errno -2
npm ERR! enoent Error while executing:
npm ERR! enoent undefined ls-remote -h -t ssh://git@github.com/masked/project.git
npm ERR! enoent
npm ERR! enoent
npm ERR! enoent spawn git ENOENT
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent

npm ERR! A complete log of this run can be found in:
npm ERR!     /opt/app-root/src/.npm/_logs/2021-04-14T22_21_42_995Z-debug.log
error: build error: error building at STEP "RUN /tmp/scripts/assemble": error while running runtime: exit status 254
```